### PR TITLE
Emphasise that SWC-Blueprint is not strictly for the SWC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ![](docs/source/_static/swc-blueprint_logo-dark_no-text.png)
 
-`SWC-Blueprint` is a project folder structure specification for use in the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/).
-It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/) widely used in human neuroimaging.
+`SWC-Blueprint` is a folder structure specification for (systems) neuroscience research projects. It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
+
+The [SWC-Blueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation, ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
+
+`SWC-Blueprint` is being developed at the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/) by members of the [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/). As such, it prioritizes interoperability with NIU-developed data analysis tools. 
+
+That said, the specification is designed to be as general as possible, and should be useful to anyone within the neuroscience field. We (the NIU) welcome [feedback](https://github.com/neuroinformatics-unit/SWC-Blueprint/discussions) and contributions from the wider community and commit to maintaining the specification as a living and evolving document. We will also collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by the [INCF](https://www.incf.org/) and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specification to non-human animal research.
 
 This repository hosts the source code for the [SWC-Blueprint website](https://swc-blueprint.neuroinformatics.dev).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SWC-Blueprint
 
-![](docs/source/_static/swc-blueprint_logo_web.png)
+![](docs/source/_static/swc-blueprint_logo-dark_no-text.png)
 
 `SWC-Blueprint` is a project folder structure specification for use in the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/).
 It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/) widely used in human neuroimaging.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -3,15 +3,13 @@
 <img src="_static/swc-blueprint_logo-light_no-text.png" alt="SWC-Blueprint logo" class="only-light img-responsive"/>
 <img src="_static/swc-blueprint_logo-dark_no-text.png" alt="SWC-Blueprint logo" class="only-dark img-responsive"/>
 
+`SWC-Blueprint` is a folder structure specification for (systems) neuroscience research projects. It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
 
-`SWC-Blueprint` is a project folder structure specification designed for the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/).
-It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
+The [SWC-Blueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation, ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
 
-The [SWC-Blueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation, ensuring consistent data management within and between labs.
+`SWC-Blueprint` is being developed at the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/) by members of the [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/). As such, it prioritizes interoperability with NIU-developed data analysis tools. 
 
-Developed by SWC's [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/), `SWC-Blueprint` ensures minimal overhead for researchers and prioritizes interoperability with NIU-developed data analysis tools. 
-
-The NIU will also collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by the [INCF](https://www.incf.org/) and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specification to non-human animal research.
+That said, the specification is designed to be as general as possible, and should be useful to anyone within the neuroscience field. We (the NIU) welcome [feedback](https://github.com/neuroinformatics-unit/SWC-Blueprint/discussions) and contributions from the wider community and commit to maintaining the specification as a living and evolving document. We will also collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by the [INCF](https://www.incf.org/) and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specification to non-human animal research.
 
 ```{toctree}
 :maxdepth: 3


### PR DESCRIPTION
Closes #25.
@adamltyson I had a go at this. Now both the README and the homepages show the same text, which emphasises that SWC-Blueprint is designed to be generally useful and that we welcome contributions.
Feel free to rephrase as you see fit. 
