### PR TITLE
Updated docs deployment workflow

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -24,6 +24,8 @@ jobs:
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs
     needs: build_sphinx_docs
+    permissions:
+      contents: write
     if: github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Added write permission for the deploy job.
[See here](https://github.com/neuroinformatics-unit/python-cookiecutter/pull/30#discussion_r1202759127) to understand why this is needed.
