### PR TITLE
Loosen the requirement for numeric labels to allow alphanumeric labels.

### DIFF
--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -56,9 +56,9 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be alphanumerical, e.g. `ses-01A`.
 * Sessions *should* be assigned ascending numerical labels as they are added to the project e.g. `ses-01`, `ses-02`. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
-* If a `date` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDD` and *should* be paired with a `date-` key e.g. `date-20250101`.
-* If a `time` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `HHMMSS` and *should* be paired with a `time-` key e.g. `time-181210`.
-* If a `datetime` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` and *should* be paired with a `datetime` key e.g. `datetime-20231225T133015`.
+* If a `date` field is added, it *should* be in the format `YYYYMMDD`.
+* If a `time` field is added, it *should* be in the format `HHMMSS`
+* If a `datetime` field is added, it *should* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` e.g. `20231225T133015`.
 * Different sessions *may* contain different combinations of datatypes.
 
 :::{hint}

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -39,8 +39,8 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 ### Subject
 
 * Each subject *must* have exactly one subject-level folder.
-* Subject-level folders *must* be prefixed with a key-value pair that is unique for each subject. The key *must* be `sub` and the value *must* be numerical, e.g. `sub-001`.
-* Subjects *should* be assigned ascending numerical labels as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s for consistent indentation and sorting, e.g. `sub-001`, `sub-002`, `sub-003`.
+* Subject-level folders *must* be prefixed with a key-value pair that is unique for each subject. The key *must* be `sub` and the value *must* be alphanumerical, e.g. `sub-123A`.
+* Subjects *should* be assigned ascending numerical labels as they are added to the project, e.g. `sub-001`, `sub-002`. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `sub` key-value pair. For example, animal IDs (e.g. from the animal facility) can be added as follows: `sub-001_id-5645332`. The keys *should* be consistent across subjects.
 
 :::{hint}
@@ -48,18 +48,17 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * invalid:
   * `mouse-01`: the first key should have been `sub`.
   * `sub-001_female`: `female` should have been written as a key-value pair (e.g. `sex-female`)
-  * `sub-B`: the `sub` key should have a numerical value
 :::
 
 ### Session
 
 * Each session *must* have exactly one session-level folder.
-* Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be numerical, e.g. `ses-01`.
-* Sessions *should* be assigned ascending numerical labels as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s for consistent indentation and sorting, e.g. `ses-01`, `ses-02`, `ses-03`.
+* Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be alphanumerical, e.g. `ses-01A`.
+* Sessions *should* be assigned ascending numerical labels as they are added to the project e.g. `ses-01`, `ses-02`. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
-* If a `date` field is added, it *should* be in the format `YYYYMMDD`.
-* If a `time` field is added, it *should* be in the format `HHMMSS`
-* If a `datetime` field is added, it *should* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` e.g. `20231225T133015`.
+* If a `date` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDD` and *should* be paired with a `date-` key e.g. `date-20250101`.
+* If a `time` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `HHMMSS` and *should* be paired with a `time-` key e.g. `time-181210`.
+* If a `datetime` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` and *should* be paired with a `datetime` key e.g. `datetime-20231225T133015`.
 * Different sessions *may* contain different combinations of datatypes.
 
 :::{hint}
@@ -67,7 +66,6 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * invalid:
   * `date-20230204_ses-01`: `ses` should have been the first key
   * `session2`: should have been written as `ses-2`
-  * `ses-A`: the `ses` key should have a numerical value
 :::
 
 ### Datatype

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -39,7 +39,7 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 ### Subject
 
 * Each subject *must* have exactly one subject-level folder.
-* Subject-level folders *must* be prefixed with a key-value pair that is unique for each subject. The key *must* be `sub` and the value *must* be alphanumerical, e.g. `sub-123A`.
+* Subject-level folders *must* be prefixed with a key-value pair that is unique for each subject. The key *must* be `sub` and the value *must* be alphanumerical, e.g. `sub-123`, `sub-ABC`, `sub-123A`.
 * Subjects *should* be assigned ascending numerical labels e.g. `sub-001`, `sub-002` increasing as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `sub` key-value pair. For example, animal IDs (e.g. from the animal facility) can be added as follows: `sub-001_id-5645332`. The keys *should* be consistent across subjects.
 
@@ -53,7 +53,7 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 ### Session
 
 * Each session *must* have exactly one session-level folder.
-* Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be alphanumerical, e.g. `ses-01A`.
+* Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be alphanumerical, e.g. `ses-123`, `ses-ABC`, `ses-123A`.
 * Sessions *should* be assigned ascending numerical labels e.g. `ses-01`, `ses-02` increasing as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
 * If a `date` field is added, it *should* be in the format `YYYYMMDD`.

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -40,7 +40,7 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 
 * Each subject *must* have exactly one subject-level folder.
 * Subject-level folders *must* be prefixed with a key-value pair that is unique for each subject. The key *must* be `sub` and the value *must* be alphanumerical, e.g. `sub-123A`.
-* Subjects *should* be assigned ascending numerical labels as they are added to the project, e.g. `sub-001`, `sub-002`. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
+* Subjects *should* be assigned ascending numerical labels e.g. `sub-001`, `sub-002` increasing as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `sub` key-value pair. For example, animal IDs (e.g. from the animal facility) can be added as follows: `sub-001_id-5645332`. The keys *should* be consistent across subjects.
 
 :::{hint}
@@ -54,7 +54,7 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 
 * Each session *must* have exactly one session-level folder.
 * Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be alphanumerical, e.g. `ses-01A`.
-* Sessions *should* be assigned ascending numerical labels as they are added to the project e.g. `ses-01`, `ses-02`. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
+* Sessions *should* be assigned ascending numerical labels e.g. `ses-01`, `ses-02` increasing as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s to ensure labels are the same length for consistent indentation and sorting.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
 * If a `date` field is added, it *should* be in the format `YYYYMMDD`.
 * If a `time` field is added, it *should* be in the format `HHMMSS`


### PR DESCRIPTION
Further to #74 this PR allows `sub-` and `ses-` labels to be alphanumeric, removing the requirement for these to be numeric only. It is still recommended that labels are (optionally zero-padded) integers increasing as each new subject / session is added, but this is no longer a fixed requirement.

thanks @glopesdev for the suggestion! It is nice to allow this level of flexibility if required.

This PR is a change to the spec so does not require tests nor further documentation. It will need to be handled on the datashuttle side and would make sense to merge this and a datashuttle PR that handles it at the same tiem.