### PR TITLE
Display .dev suffix in release name

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ author = 'Neuroinformatics Unit'
 # Retrieve the version number from the package
 try:
     release = setuptools_scm.get_version(root="../..", relative_to=__file__)
-    release = release.split(".dev")[0]  # remove dev tag and git hash
+    release = release.split("+")[0]  # remove git hash but retain .dev tag if present
 except LookupError:
     # if git is not initialised, still allow local build
     # with a dummy version


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We now also show a "dev" version of the docs (corresponding to the `main` branch), see #78, but the displayed release doesn't always make sense.

For example, if the latest tagged version is `v0.3.3`, `setuptools_csm` will label commits after that as `v0.3.4.dev{N}+{commit-hash}`. Our code in Sphinx's `conf.py` trims that to just `v0.3.4` so it's not apparent that this is a development version of `v0.3.4` and instead it looks like the release `v0.3.4`.

**What does this PR do?**

It changes the trimming logic such that the `.dev` suffix is preserved if present.
The hash is still removed. So the above example will be now displayed as `v0.3.4.dev5` (number after `dev` varies).

## References

https://github.com/neuroinformatics-unit/NeuroBlueprint/pull/78

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
