### PR TITLE
Fix version matching in docs version switcher dropdown

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,11 +25,17 @@ author = 'Neuroinformatics Unit'
 # Retrieve the version number from the package
 try:
     release = setuptools_scm.get_version(root="../..", relative_to=__file__)
-    release = release.split("+")[0]  # remove git hash but retain .dev tag if present
+    release = release.split("+")[0]  # remove git hash
 except LookupError:
     # if git is not initialised, still allow local build
     # with a dummy version
     release = "0.0.0"
+
+# Release labels for the version switcher dropdown
+if "dev" in release:
+    doc_version = "dev"
+else:
+    doc_version = f"v{release}"
 
 
 # -- General configuration ---------------------------------------------------
@@ -130,7 +136,7 @@ html_theme_options = {
     ],
     "switcher": {
         "json_url": "https://neuroblueprint.neuroinformatics.dev/latest/_static/switcher.json",
-        "version_match": release,
+        "version_match": doc_version,
     },
     "logo": {
         "text": f"NeuroBlueprint v{release}",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Quoting myself from [this comment](https://github.com/neuroinformatics-unit/movement/pull/668#issuecomment-3324873945)

> there is one remaining snug: if you look at the version switcher dropdown at [neuroblueprint.neuroinformatics.dev/latest/index.html](https://neuroblueprint.neuroinformatics.dev/latest/index.html), it displays "Choose version" no matter which version we've selected. The expected behaviour is for the currently selected version to be displayed there, as is the case for the NumPy docs website: [numpy.org/doc/1.26/index.html](https://numpy.org/doc/1.26/index.html)

**What does this PR do?**

We think we've pinned down the issue to erroneous version matching in the `conf.py` file, see the discussion under https://github.com/neuroinformatics-unit/movement/pull/668

This PR implements a fix suggested by @animeshsasan in [this comment](https://github.com/neuroinformatics-unit/movement/pull/668#issuecomment-3331722731).

## References

https://github.com/neuroinformatics-unit/movement/pull/668

## How has this PR been tested?

Not tested, the real test will happen upon merging to main.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
