### PR TITLE
Reorder website icons

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,7 +143,7 @@ html_theme_options = {
         "image_light": "logo_light.png",
         "image_dark": "logo_dark.png",
     },
-    "navbar_end": ["version-switcher","navbar-icon-links", "theme-switcher"],
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "footer_start": ["custom_footer"],
     "footer_end": ["footer_end"]
 }


### PR DESCRIPTION
Reorder the header icons to match other websites (e.g. [movement](https://movement.neuroinformatics.dev/latest/index.html))

new order: 

<img width="1442" height="78" alt="image" src="https://github.com/user-attachments/assets/b48dedc0-5299-400a-9d7b-09c73885dc57" />

